### PR TITLE
Make codecov upload step faster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ main, fix/slow-coverage ]
+    branches: [ main ]
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, fix/slow-coverage ]
   pull_request:
     branches:
       - main
@@ -36,7 +36,10 @@ jobs:
                   --excl-line '#\[|=> panic!|unreachable!|Io\(std::io::Error\)' \
                   --excl-br-line '#\[|=> panic!|unreachable!|assert_..!|assert_approx_eq!' -o ./coverage/lcov.info
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          file: ${{ steps.coverage.outputs.report }}
-          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          curl -s https://codecov.io/bash | bash -s -- \
+          -F "unittests" \
+          -f ./coverage/lcov.info
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - name: Select Rust nightly build
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
# Summary

`codecov/codecov-action` builds docker to upload coverage.
However, building docker is quite slow without cache.
So I changed it to use bash script directly.

# Includes

- [x] Change `codecov/codecov-action` directly use bash script
- [x] Make codecov detect commit sha