### PR TITLE
Use cache for build & test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Select Rust nightly build
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
# Summary

Cargo steps in build & test workflow is slow because there is no cache.
So I updated workflow to use cache.

## Before
![image](https://user-images.githubusercontent.com/46488521/162176347-2970d8b9-d3b6-4fce-bc2b-c94f9a5b5c1c.png)
https://github.com/OxideEngine/Oxide/actions/runs/2108137044

## After
![image](https://user-images.githubusercontent.com/46488521/162176368-4ea6304d-b5ac-49ad-9c9d-789c2ea10161.png)
https://github.com/OxideEngine/Oxide/actions/runs/2108168975

# Includes

- [x] added caching step
