### PR TITLE
Fix codecov coverage uploader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,10 @@ jobs:
                   --excl-line '#\[|=> panic!|unreachable!|Io\(std::io::Error\)' \
                   --excl-br-line '#\[|=> panic!|unreachable!|assert_..!|assert_approx_eq!' -o ./coverage/lcov.info
       - name: Upload to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: |
-          curl -s https://codecov.io/bash | bash -s -- \
-          -F "unittests" \
-          -f ./coverage/lcov.info
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: unittests
+          verbose: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TEST_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           flags: unittests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TEST_TOKEN }}
           files: ./coverage/lcov.info
           flags: unittests
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,4 @@ jobs:
           token: ${{ secrets.CODECOV_TEST_TOKEN }}
           files: ./coverage/lcov.info
           flags: unittests
-          verbose: true
 


### PR DESCRIPTION
# Summary

Due to deprecation of bash uploader, use predefined codecov action step.
Plus, changed target upload to updated repo url.

# Includes

- [x] change upload step to predefined one(updated version)
- [x] changed target token

# Things to know

I used `CODECOV_TEST_TOKEN` secret.
It will be updated to `CODECOV_TOKEN` before merging.

Updated coverage badge is included in #38.

